### PR TITLE
FIX: simplify class name for other WM's

### DIFF
--- a/rc/alacritty.kak
+++ b/rc/alacritty.kak
@@ -6,7 +6,7 @@ provide-module alacritty %{
   }
 
   define-command alacritty-popup -params .. -shell-completion -docstring 'Open a new terminal as a popup' %{
-    alacritty --class 'Alacritty · Popup' %arg{@}
+    alacritty --class 'Alacritty-Popup' %arg{@}
   }
 
   # Conform to terminal as aliases


### PR DESCRIPTION
I simplified the class format so it is less ambiguous and more easily used in other WM's (like spectrwm for me)